### PR TITLE
Fix exception when receiving keep alive signal

### DIFF
--- a/Filtered_Stream/filtered_stream.js
+++ b/Filtered_Stream/filtered_stream.js
@@ -106,7 +106,12 @@ function streamConnect(token) {
   const stream = request.get(config);
 
   stream.on('data', data => {
-      console.log(JSON.parse(data));
+    try {
+      const json = JSON.parse(data);
+      console.log(json);
+    } catch (e) {
+      // Keep alive signal received. Do nothing.
+    }
   }).on('error', error => {
     if (error.code === 'ETIMEDOUT') {
       stream.emit('timeout');


### PR DESCRIPTION
### Problem

As reported in the forums, the JavaScript Quick Start crashes when receiving a keep alive signal.

### Solution

This PR fixes the crash by parsing JSON safely in a try/catch block. When the stream serves a keep alive signal, the client will attempt to JSON parse it. If it fails, nothing happens. If it succeeds, it means it is valid JSON and it will be rendered to the console.

### Result

You should expect the stream to stay connected for as long as it's allowed.